### PR TITLE
make the login service a bit more configurable

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -19,6 +19,27 @@ trigger:
 ---
 kind: pipeline
 type: docker
+name: push-feature-build
+steps:
+- name: push-feature-build
+  image: plugins/docker
+  settings:
+    repo: ${DRONE_REPO}
+    tags: ${DRONE_BRANCH/\//-}
+    username:
+      from_secret: docker_username
+    password:
+      from_secret: docker_password
+    purge: true
+trigger:
+  branch:
+    - feature/*
+  event:
+    exclude:
+      - pull_request
+---
+kind: pipeline
+type: docker
 name: push-release
 steps:
 - name: build-and-push-tag

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The following enviroment variables can be configured:
 * `DEBUG_LOG_TOKENSETS`: When set, received tokenSet information is logged to the console.
 * `LOG_SINK_URL`: When set, log tokenSet information to that configured sink.
 * `LOGS_GRAPH` [string]: URI of the graph in which LogEntries are stored (default `http://mu.semte.ch/graphs/public`).
+* `SESSION_GRAPH` [string]: URI of the graph in which sessions are stored (default `http://mu.semte.ch/graphs/sessions`)
+* `ACCOUNT_GRAPH_TEMPLATE` [string]: URI template of the graph in which accounts are stored. You can (optionally use) `{{groupId}}` (default `http://mu.semte.ch/graphs/organizations/{{groupId}}`)
+* `USER_GRAPH_TEMPLATE` [string]: URI template of the graph in which users are stored. You can (optionally use) `{{groupId}}` (default `http://mu.semte.ch/graphs/organizations/{{groupId}}`)
 
 ## Available requests
 

--- a/config.js
+++ b/config.js
@@ -1,0 +1,9 @@
+export const USER_ID_CLAIM = process.env.MU_APPLICATION_AUTH_USERID_CLAIM || 'rrn';
+export const ACCOUNT_ID_CLAIM = process.env.MU_APPLICATION_AUTH_ACCOUNTID_CLAIM || 'vo_id';
+export const GROUP_ID_CLAIM = process.env.MU_APPLICATION_AUTH_GROUPID_CLAIM || 'vo_orgcode';
+export const ROLE_CLAIM = process.env.MU_APPLICATION_AUTH_ROLE_CLAIM || 'abb_loketLB_rol_3d';
+export const RESOURCE_BASE_URI = process.env.MU_APPLICATION_RESOURCE_BASE_URI || 'http://data.lblod.info/';
+export const USER_GRAPH_TEMPLATE = process.env.USER_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
+export const ACCOUNT_GRAPH_TEMPLATE = process.env.ACCOUNT_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
+export const SESSION_GRAPH = process.env.SESSION_GRAPH || "http://mu.semte.ch/graphs/sessions";
+export const ORGANIZATION_TYPE = "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid";

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,17 +1,30 @@
 import { uuid, sparqlEscapeUri, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
+import {
+  USER_ID_CLAIM as userIdClaim,
+  ACCOUNT_ID_CLAIM as accountIdClaim,
+  GROUP_ID_CLAIM as groupIdClaim,
+  ROLE_CLAIM as roleClaim,
+  RESOURCE_BASE_URI as resourceBaseUri,
+  USER_GRAPH_TEMPLATE,
+  ACCOUNT_GRAPH_TEMPLATE,
+  SESSION_GRAPH,
+  ORGANIZATION_TYPE
+} from '../config';
 
 const serviceHomepage = 'https://github.com/lblod/acmidm-login-service';
-const resourceBaseUri = process.env.MU_APPLICATION_RESOURCE_BASE_URI || 'http://data.lblod.info/';
 const personResourceBaseUri = `${resourceBaseUri}id/persoon/`;
 const accountResourceBaseUri = `${resourceBaseUri}id/account/`;
 const identifierResourceBaseUri = `${resourceBaseUri}id/identificator/`;
 
-const userIdClaim = process.env.MU_APPLICATION_AUTH_USERID_CLAIM || 'rrn';
-const accountIdClaim = process.env.MU_APPLICATION_AUTH_ACCOUNTID_CLAIM || 'vo_id';
-const groupIdClaim = process.env.MU_APPLICATION_AUTH_GROUPID_CLAIM || 'vo_orgcode';
-const roleClaim = process.env.MU_APPLICATION_AUTH_ROLE_CLAIM || 'abb_loketLB_rol_3d';
 
+function accountGraphFor(params) {
+  return ACCOUNT_GRAPH_TEMPLATE.replace('{{groupId}}', params.groupId);
+}
+
+function userGraphFor(params) {
+  return USER_GRAPH_TEMPLATE.replace('{{groupId}}', params.groupId);
+}
 const removeOldSessions = async function(sessionUri) {
   await update(
     `PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -20,7 +33,7 @@ const removeOldSessions = async function(sessionUri) {
      PREFIX dcterms: <http://purl.org/dc/terms/>
 
      DELETE WHERE {
-       GRAPH <http://mu.semte.ch/graphs/sessions> {
+       GRAPH ${sparqlEscapeUri(SESSION_GRAPH)} {
            ${sparqlEscapeUri(sessionUri)} session:account ?account ;
                                           mu:uuid ?id ;
                                           dcterms:modified ?modified ;
@@ -35,9 +48,10 @@ const removeCurrentSession = async function(sessionUri) {
 };
 
 const ensureUserAndAccount = async function(claims, groupId) {
-  const graph = `http://mu.semte.ch/graphs/organizations/${groupId}`;
-  const { personUri } = await ensureUser(claims, graph);
-  const { accountUri, accountId } = await ensureAccountForUser(personUri, claims, graph);
+  const userGraph = userGraphFor({groupId});
+  const accountGraph = accountGraphFor({groupId});
+  const { personUri } = await ensureUser(claims, userGraph);
+  const { accountUri, accountId } = await ensureAccountForUser(personUri, claims, accountGraph);
   return { accountUri, accountId };
 };
 
@@ -180,7 +194,7 @@ const insertNewSessionForAccount = async function(accountUri, sessionUri, groupU
     PREFIX dcterms: <http://purl.org/dc/terms/>
 
     INSERT DATA {
-      GRAPH <http://mu.semte.ch/graphs/sessions> {
+      GRAPH ${sparqlEscapeUri(SESSION_GRAPH)} {
         ${sparqlEscapeUri(sessionUri)} mu:uuid ${sparqlEscapeString(sessionId)} ;
                                  session:account ${sparqlEscapeUri(accountUri)} ;
                                  ext:sessionGroup ${sparqlEscapeUri(groupUri)} ;`;
@@ -208,7 +222,7 @@ const selectBestuurseenheidByNumber = async function(claims) {
     SELECT ?group ?groupId
     FROM <${process.env.MU_APPLICATION_GRAPH}>
     WHERE {
-      ?group a <http://data.vlaanderen.be/ns/besluit#Bestuurseenheid> ;
+      ?group a ${sparqlEscapeUri(ORGANIZATION_TYPE)} ;
              mu:uuid ?groupId ;
              dcterms:identifier ${sparqlEscapeString(identifier)} .
     }`);
@@ -222,7 +236,30 @@ const selectBestuurseenheidByNumber = async function(claims) {
   return { groupUri: null, groupId: null };
 };
 
-const selectAccountBySession = async function(session) {
+async function getGroupIdForSession(session) {
+  const queryResult = await query(`
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    SELECT DISTINCT ?groupId WHERE {
+       GRAPH ${sparqlEscapeUri(SESSION_GRAPH)} {
+          ${sparqlEscapeUri(session)} ext:sessionGroup ?group .
+      }
+      GRAPH <${process.env.MU_APPLICATION_GRAPH}> {
+      ?group a ${sparqlEscapeUri(ORGANIZATION_TYPE)} ;
+             mu:uuid ?groupId .
+      }
+      }
+  `);
+  if (queryResult.results.bindings.length) {
+    const result = queryResult.results.bindings[0];
+    return result.groupId.value;
+  }
+  else
+    return null;
+}
+
+async function selectAccountBySession(session) {
+  const groupId = await getGroupIdForSession(session);
   const queryResult = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -232,19 +269,13 @@ const selectAccountBySession = async function(session) {
 
     SELECT ?account ?accountId
     WHERE {
-      GRAPH <http://mu.semte.ch/graphs/sessions> {
-          ${sparqlEscapeUri(session)} session:account ?account ;
-                                      ext:sessionGroup ?group .
+       GRAPH ${sparqlEscapeUri(SESSION_GRAPH)} {
+          ${sparqlEscapeUri(session)} session:account ?account.
       }
-      GRAPH <${process.env.MU_APPLICATION_GRAPH}> {
-          ?group a besluit:Bestuurseenheid ;
-                 mu:uuid ?groupId .
-      }
-      GRAPH ?g {
+      GRAPH ${sparqlEscapeUri(accountGraphFor(groupId))} {
           ?account a foaf:OnlineAccount ;
                    mu:uuid ?accountId .
       }
-      FILTER(?g = IRI(CONCAT("http://mu.semte.ch/graphs/organizations/", ?groupId)))
     }`);
 
   if (queryResult.results.bindings.length) {
@@ -264,7 +295,7 @@ const selectCurrentSession = async function(account) {
 
     SELECT ?session ?sessionId ?group ?groupId (GROUP_CONCAT(?role; SEPARATOR = ',') as ?roles)
     WHERE {
-      GRAPH <http://mu.semte.ch/graphs/sessions> {
+       GRAPH ${sparqlEscapeUri(SESSION_GRAPH)} {
           ?session session:account ${sparqlEscapeUri(account)} ;
                    mu:uuid ?sessionId ;
                    ext:sessionGroup ?group ;


### PR DESCRIPTION
makes it possible to configure:
- the graph users are stored in
- the graph accounts are stored in
- the graph sessions are stored in

I think this should make it possible to reuse the base service in contacthub and the initial case for mow registry
example config from mow-registry:

```
  login:
    image: lblod/acmidm-login-service:feature-configurable
    links:
      - db:database
    environment:
      MU_APPLICATION_AUTH_DISCOVERY_URL: https://authenticatie-ti.vlaanderen.be/op/.well-known/openid-configuration 
      MU_APPLICATION_AUTH_CLIENT_ID:  configure-in-override
      MU_APPLICATION_AUTH_CLIENT_SECRET: configure-in-override
      MU_APPLICATION_AUTH_REDIRECT_URI: https://roadsigns.lblod.info/authorization/callback
      MU_APPLICATION_AUTH_USERID_CLAIM: sub
      USER_GRAPH_TEMPLATE: http://mu.semte.ch/graphs/users
      ACCOUNT_GRAPH_TEMPLATE: http://mu.semte.ch/graphs/users
      ROLE_CLAIM: abb_registiermobiliteit_rol_3d
```

basic testing seems to indicate it works as expected, should also be perfectly backwards compatible for loket/gn etc