### PR TITLE
Allow economische actoren to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The following environment variables can optionally be set:
 * `DEBUG_LOG_TOKENSETS`: When set, received tokenSet information is logged to the console.
 * `LOG_SINK_URL`: When set, received tokenSet information is sent to the configured sink URL.
 * `MU_APPLICATION_AUTH_REQUEST_TIMEOUT` [int]: Timeout in ms of OpenID HTTP requests (default `5000`)
+* `ORGANIZATION_TYPE` [string]: Defines the group type linked to an account (default `http://data.vlaanderen.be/ns/besluit#Bestuurseenheid`)
+* `GROUP_TYPE_LABEL` [string]: Defines the resources group type label (default 'bestuurseenheden')
 
 ### Data model
 #### Prefixes

--- a/app.js
+++ b/app.js
@@ -5,8 +5,9 @@ import { getAccessToken } from './lib/openid';
 import { roleClaim, groupIdClaim, removeOldSessions, removeCurrentSession,
          ensureUserAndAccount, insertNewSessionForAccount,
          selectAccountBySession, selectCurrentSession,
-         selectBestuurseenheidByNumber } from './lib/session';
+         selectGroupByNumber } from './lib/session';
 import request from 'request';
+import { GROUP_TYPE_LABEL } from './config';
 
 const logsGraph = process.env.LOGS_GRAPH || 'http://mu.semte.ch/graphs/public';
 
@@ -70,7 +71,7 @@ app.post('/sessions', async function(req, res, next) {
     if (process.env['LOG_SINK_URL'])
       request.post({ url: process.env['LOG_SINK_URL'], body: tokenSet, json: true });
 
-    const { groupUri, groupId } = await selectBestuurseenheidByNumber(claims);
+    const { groupUri, groupId } = await selectGroupByNumber(claims);
 
     if (!groupUri || !groupId) {
       console.log(`User is not allowed to login. No bestuurseenheid found for roles ${JSON.stringify(claims[roleClaim])}`);
@@ -105,8 +106,8 @@ app.post('/sessions', async function(req, res, next) {
           data: { type: 'accounts', id: accountId }
         },
         group: {
-          links: { related: `/bestuurseenheden/${groupId}` },
-          data: { type: 'bestuurseenheden', id: groupId }
+          links: { related: `/${GROUP_TYPE_LABEL}/${groupId}` },
+          data: { type: GROUP_TYPE_LABEL, id: groupId }
         }
       }
     });
@@ -175,8 +176,8 @@ app.get('/sessions/current', async function(req, res, next) {
           data: { type: 'accounts', id: accountId }
         },
         group: {
-          links: { related: `/bestuurseenheden/${groupId}` },
-          data: { type: 'bestuurseenheden', id: groupId }
+          links: { related: `/${GROUP_TYPE_LABEL}/${groupId}` },
+          data: { type: GROUP_TYPE_LABEL, id: groupId }
         }
       }
     });

--- a/app.js
+++ b/app.js
@@ -5,7 +5,8 @@ import { getAccessToken } from './lib/openid';
 import { roleClaim, groupIdClaim, removeOldSessions, removeCurrentSession,
          ensureUserAndAccount, insertNewSessionForAccount,
          selectAccountBySession, selectCurrentSession,
-         selectGroupByNumber } from './lib/session';
+         selectGroupByNumber, 
+         createEconomischeActorByClaims} from './lib/session';
 import request from 'request';
 import { GROUP_TYPE_LABEL } from './config';
 
@@ -71,17 +72,30 @@ app.post('/sessions', async function(req, res, next) {
     if (process.env['LOG_SINK_URL'])
       request.post({ url: process.env['LOG_SINK_URL'], body: tokenSet, json: true });
 
-    const { groupUri, groupId } = await selectGroupByNumber(claims);
+    let { groupUri, groupId } = await selectGroupByNumber(claims);
+
+    const isEconomischeActor = claims.vo_doelgroepcode == "EA"
 
     if (!groupUri || !groupId) {
-      console.log(`User is not allowed to login. No bestuurseenheid found for roles ${JSON.stringify(claims[roleClaim])}`);
-      saveLog(
-        logsGraph,
-        `http://data.lblod.info/class-names/no-bestuurseenheid-for-role`,
-        `User is not allowed to login. No bestuurseenheid found for roles ${JSON.stringify(claims[roleClaim])}`,
-        sessionUri,
-        claims[groupIdClaim]);
-      return res.header('mu-auth-allowed-groups', 'CLEAR').status(403).end();
+      if(isEconomischeActor) {
+        await createEconomischeActorByClaims(claims);
+        ({ groupUri, groupId } = await selectGroupByNumber(claims));  
+
+
+        if (!groupUri || !groupId) {
+          console.log(`Error: GroupUri and GroupID are still empty even after creating them! Claims = ${JSON.stringify(claims)}`);
+          return res.header('mu-auth-allowed-groups', 'CLEAR').status(500).end();
+        }
+      } else {
+        console.log(`User is not allowed to login. No bestuurseenheid found for roles ${JSON.stringify(claims[roleClaim])}`);
+        saveLog(
+          logsGraph,
+          `http://data.lblod.info/class-names/no-bestuurseenheid-for-role`,
+          `User is not allowed to login. No bestuurseenheid found for roles ${JSON.stringify(claims[roleClaim])}`,
+          sessionUri,
+          claims[groupIdClaim]);
+        return res.header('mu-auth-allowed-groups', 'CLEAR').status(403).end();
+      }
     }
 
     const { accountUri, accountId } = await ensureUserAndAccount(claims, groupId);

--- a/config.js
+++ b/config.js
@@ -7,3 +7,4 @@ export const USER_GRAPH_TEMPLATE = process.env.USER_GRAPH_TEMPLATE || "http://mu
 export const ACCOUNT_GRAPH_TEMPLATE = process.env.ACCOUNT_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
 export const SESSION_GRAPH = process.env.SESSION_GRAPH || "http://mu.semte.ch/graphs/sessions";
 export const ORGANIZATION_TYPE = "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid";
+export const GROUP_TYPE_LABEL = process.env.GROUP_TYPE_LABEL || "bestuurseenheden"

--- a/config.js
+++ b/config.js
@@ -6,5 +6,5 @@ export const RESOURCE_BASE_URI = process.env.MU_APPLICATION_RESOURCE_BASE_URI ||
 export const USER_GRAPH_TEMPLATE = process.env.USER_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
 export const ACCOUNT_GRAPH_TEMPLATE = process.env.ACCOUNT_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
 export const SESSION_GRAPH = process.env.SESSION_GRAPH || "http://mu.semte.ch/graphs/sessions";
-export const ORGANIZATION_TYPE = "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid";
+export const ORGANIZATION_TYPE = process.env.ORGANIZATION_TYPE || "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid";
 export const GROUP_TYPE_LABEL = process.env.GROUP_TYPE_LABEL || "bestuurseenheden"

--- a/lib/session.js
+++ b/lib/session.js
@@ -207,7 +207,7 @@ const insertNewSessionForAccount = async function(accountUri, sessionUri, groupU
   return { sessionUri, sessionId };
 };
 
-const selectBestuurseenheidByNumber = async function(claims) {
+const selectGroupByNumber = async function(claims) {
   if (claims[groupIdClaim]) {
     const identifier = claims[groupIdClaim];
 
@@ -321,7 +321,7 @@ export {
   removeCurrentSession,
   ensureUserAndAccount,
   insertNewSessionForAccount,
-  selectBestuurseenheidByNumber,
+  selectGroupByNumber,
   selectAccountBySession,
   selectCurrentSession,
   userIdClaim,

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,8 +117,8 @@ const insertNewUser = async function(claims, graph) {
 };
 
 const ensureAccountForUser = async function(personUri, claims, graph) {
-  const accountId = accountIdClaim ? claims[accountIdClaim] : uuid();
-  
+  const accountId = claims[accountIdClaim] ?? uuid();
+
   const queryResult = await query(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -147,7 +147,7 @@ const insertNewAccountForUser = async function(person, claims, graph) {
   const account = `${accountResourceBaseUri}${accountId}`;
   const now = new Date();
 
-  const identifierClaim = accountIdClaim ? claims[accountIdClaim] : uuid();
+  const identifierClaim = claims[accountIdClaim] ?? uuid();
 
   let insertData = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>

--- a/lib/session.js
+++ b/lib/session.js
@@ -214,14 +214,25 @@ const selectGroupByNumber = async function(claims) {
     const queryResult = await query(`
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
     PREFIX dcterms: <http://purl.org/dc/terms/>
-
-    SELECT ?group ?groupId
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+             
+    SELECT DISTINCT ?group ?groupId
     FROM <${process.env.MU_APPLICATION_GRAPH}>
     WHERE {
-      ?group a ${sparqlEscapeUri(ORGANIZATION_TYPE)} ;
-             mu:uuid ?groupId ;
-             dcterms:identifier ${sparqlEscapeString(identifier)} .
-    }`);
+      ?group a ${sparqlEscapeUri(ORGANIZATION_TYPE)};
+            mu:uuid ?groupId .
+
+      {
+        ?group dcterms:identifier ${sparqlEscapeString(identifier)} .
+      }
+      UNION
+      {
+        ?group adms:identifier/skos:notation ${sparqlEscapeString(identifier)} .
+      }
+    }
+  `);
 
     if (queryResult.results.bindings.length) {
       const result = queryResult.results.bindings[0];
@@ -356,6 +367,7 @@ export {
   removeCurrentSession,
   ensureUserAndAccount,
   insertNewSessionForAccount,
+  createEconomischeActorByClaims,
   selectGroupByNumber,
   selectAccountBySession,
   selectCurrentSession,

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,7 +117,7 @@ const insertNewUser = async function(claims, graph) {
 };
 
 const ensureAccountForUser = async function(personUri, claims, graph) {
-  const accountId = claims[accountIdClaim];
+  const accountId = claims[accountIdClaim] || uuid();
 
   const queryResult = await query(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -147,6 +147,8 @@ const insertNewAccountForUser = async function(person, claims, graph) {
   const account = `${accountResourceBaseUri}${accountId}`;
   const now = new Date();
 
+  const identifierClaim = claims[accountIdClaim] || uuid();
+
   let insertData = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -159,7 +161,7 @@ const insertNewAccountForUser = async function(person, claims, graph) {
         ${sparqlEscapeUri(account)} a foaf:OnlineAccount ;
                                  mu:uuid ${sparqlEscapeString(accountId)} ;
                                  foaf:accountServiceHomepage ${sparqlEscapeUri(serviceHomepage)} ;
-                                 dcterms:identifier ${sparqlEscapeString(claims[accountIdClaim])} ;
+                                 dcterms:identifier ${sparqlEscapeString(claims[identifierClaim])} ;
                                  dcterms:created ${sparqlEscapeDateTime(now)} .
     `;
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,8 +117,8 @@ const insertNewUser = async function(claims, graph) {
 };
 
 const ensureAccountForUser = async function(personUri, claims, graph) {
-  const accountId = claims[accountIdClaim] || uuid();
-
+  const accountId = accountIdClaim ? claims[accountIdClaim] : uuid();
+  
   const queryResult = await query(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
     PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
@@ -147,7 +147,7 @@ const insertNewAccountForUser = async function(person, claims, graph) {
   const account = `${accountResourceBaseUri}${accountId}`;
   const now = new Date();
 
-  const identifierClaim = claims[accountIdClaim] || uuid();
+  const identifierClaim = accountIdClaim ? claims[accountIdClaim] : uuid();
 
   let insertData = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>

--- a/lib/session.js
+++ b/lib/session.js
@@ -161,7 +161,7 @@ const insertNewAccountForUser = async function(person, claims, graph) {
         ${sparqlEscapeUri(account)} a foaf:OnlineAccount ;
                                  mu:uuid ${sparqlEscapeString(accountId)} ;
                                  foaf:accountServiceHomepage ${sparqlEscapeUri(serviceHomepage)} ;
-                                 dcterms:identifier ${sparqlEscapeString(claims[identifierClaim])} ;
+                                 dcterms:identifier ${sparqlEscapeString(identifierClaim)} ;
                                  dcterms:created ${sparqlEscapeDateTime(now)} .
     `;
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -316,6 +316,41 @@ const selectCurrentSession = async function(account) {
   }
 };
 
+const createEconomischeActorByClaims = async function(claims) {
+  const now = new Date();
+
+  const orgUuid = claims.vo_id;
+  const orgUri = `http://data.lblod.info/id/organisaties/${orgUuid}`;
+
+  const identificatorUuid = uuid();
+  const identificatorUri =  `http://data.lblod.info/id/identificatoren/${identificatorUuid}`;
+
+  let insertData = `
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+    PREFIX dc: <http://purl.org/dc/terms/>
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX org: <http://www.w3.org/ns/org#>
+
+    INSERT DATA {
+      GRAPH <http://mu.semte.ch/graphs/public> {
+        ${sparqlEscapeUri(orgUri)} a org:Organization ;
+            mu:uuid ${sparqlEscapeString(orgUuid)};
+            skos:prefLabel ${sparqlEscapeString(claims.vo_orgnaam)} ;
+            org:classification <http://data.lblod.info/id/concept/c6157470-9fb3-4e8d-a9b7-8737dbfa3642> ;
+            adms:identifier ${sparqlEscapeUri(identificatorUri)};
+            dc:created ${sparqlEscapeDateTime(now)};
+            dc:modified ${sparqlEscapeDateTime(now)}.
+
+        ${sparqlEscapeUri(identificatorUri)} a adms:Identifier;
+            mu:uuid ${sparqlEscapeString(identificatorUuid)};
+            skos:notation ${sparqlEscapeString(claims.vo_orgcode)}.
+      }
+    }`;
+
+  await update(insertData);
+};
+
 export {
   removeOldSessions,
   removeCurrentSession,

--- a/lib/session.js
+++ b/lib/session.js
@@ -330,7 +330,7 @@ const selectCurrentSession = async function(account) {
 const createEconomischeActorByClaims = async function(claims) {
   const now = new Date();
 
-  const orgUuid = claims.vo_id;
+  const orgUuid = uuid();
   const orgUri = `http://data.lblod.info/id/organisaties/${orgUuid}`;
 
   const identificatorUuid = uuid();

--- a/lib/session.js
+++ b/lib/session.js
@@ -117,7 +117,7 @@ const insertNewUser = async function(claims, graph) {
 };
 
 const ensureAccountForUser = async function(personUri, claims, graph) {
-  const accountId = claims[accountIdClaim] ?? uuid();
+  const accountId = claims[accountIdClaim] ?? claims["sub"];
 
   const queryResult = await query(`
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>
@@ -147,7 +147,7 @@ const insertNewAccountForUser = async function(person, claims, graph) {
   const account = `${accountResourceBaseUri}${accountId}`;
   const now = new Date();
 
-  const identifierClaim = claims[accountIdClaim] ?? uuid();
+  const identifierClaim = claims[accountIdClaim] ?? claims["sub"] ;
 
   let insertData = `
     PREFIX foaf: <http://xmlns.com/foaf/0.1/>


### PR DESCRIPTION
## ID
DGS-282

## Description
This PR enables economische actoren to login through acmidm

## Type of change

 - [ ] Bug fix
 - [x] New feature
 - [ ] Breaking change
 - [ ] Maintanance

## How to setup
Best to setup on a server rather then locally. add the following to your docker-compose.override

```
  login:
   image: "aatauil/acmidm-login-service:verenigingen-0.0.1"
    environment:
      ...
      ORGANIZATION_TYPE: "http://www.w3.org/ns/org#Organization"
      GROUP_TYPE_LABEL: "organizations"
```

## How to test
go to subsidiepunt url. login. If you have multiple org assigned to you, try login-in with a economische actor. Also try with bestuurseenheid to make sure it still works