### PR TITLE
[LPDC-1645]: add support for the vo_email claim behind a feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following environment variables can optionally be set to configure the graph
 * `LOGS_GRAPH` [string]: URI of the graph in which LogEntries are stored (default `http://mu.semte.ch/graphs/public`).
 
 The following environment variables can optionally be set:
+* `ENABLE_EMAIL_CLAIM` [boolean]: When set to `true`, the service processes and stores the user's email address from the `vo_email` claim. (default `false`)
 * `DEBUG_LOG_TOKENSETS`: When set, received tokenSet information is logged to the console.
 * `LOG_SINK_URL`: When set, received tokenSet information is sent to the configured sink URL.
 * `MU_APPLICATION_AUTH_REQUEST_TIMEOUT` [int]: Timeout in ms of OpenID HTTP requests (default `5000`)
@@ -122,6 +123,7 @@ The following environment variables can optionally be set:
 | identifier | adms:identifier | adms:Identifier | Unique identifier of the user |
 | firstName  | foaf:firstName  | string          | First name of the user        |
 | familyName | foaf:familyName | string          | Last name of the user         |
+| email      | foaf:email      | string          | Email address of the user     |
 
 #### Identifier
 ##### Class

--- a/config.js
+++ b/config.js
@@ -7,3 +7,4 @@ export const USER_GRAPH_TEMPLATE = process.env.USER_GRAPH_TEMPLATE || "http://mu
 export const ACCOUNT_GRAPH_TEMPLATE = process.env.ACCOUNT_GRAPH_TEMPLATE || "http://mu.semte.ch/graphs/organizations/{{groupId}}";
 export const SESSION_GRAPH = process.env.SESSION_GRAPH || "http://mu.semte.ch/graphs/sessions";
 export const ORGANIZATION_TYPE = "http://data.vlaanderen.be/ns/besluit#Bestuurseenheid";
+export const ENABLE_EMAIL_CLAIM = process.env.ENABLE_EMAIL_CLAIM === 'true';

--- a/lib/session.js
+++ b/lib/session.js
@@ -61,13 +61,13 @@ const ensureUser = async function(claims, graph) {
     PREFIX adms: <http://www.w3.org/ns/adms#>
     PREFIX dcterms: <http://purl.org/dc/terms/>
 
-    SELECT ?person ?personId
+    SELECT ?person ?personId ?email
     FROM <${graph}> {
       ?person a foaf:Person ;
             mu:uuid ?personId ;
             adms:identifier ?identifier .
       ?identifier skos:notation ${sparqlEscapeString(userId)} .
-      OPTIONAL { ?person foaf:email ?email . }
+      ${enableEmailClaim ? 'OPTIONAL { ?person foaf:email ?email . }' : ''}
     }`);
 
   if (queryResult.results.bindings.length) {
@@ -75,8 +75,8 @@ const ensureUser = async function(claims, graph) {
     const personUri = result.person.value;
     const personId = result.personId.value;
 
-    if(enableEmailClaim &&claims.vo_email && !result.email) {
-      await insertEmailForExistingUser(personUri, claims, graph)
+    if (enableEmailClaim && claims.vo_email && !result.email) {
+      await insertEmailForExistingUser(personUri, claims, graph);
     }
 
     return { personUri, personId };

--- a/lib/session.js
+++ b/lib/session.js
@@ -6,6 +6,7 @@ import {
   GROUP_ID_CLAIM as groupIdClaim,
   ROLE_CLAIM as roleClaim,
   RESOURCE_BASE_URI as resourceBaseUri,
+  ENABLE_EMAIL_CLAIM as enableEmailClaim,
   USER_GRAPH_TEMPLATE,
   ACCOUNT_GRAPH_TEMPLATE,
   SESSION_GRAPH,
@@ -66,11 +67,19 @@ const ensureUser = async function(claims, graph) {
             mu:uuid ?personId ;
             adms:identifier ?identifier .
       ?identifier skos:notation ${sparqlEscapeString(userId)} .
+      OPTIONAL { ?person foaf:email ?email . }
     }`);
 
   if (queryResult.results.bindings.length) {
     const result = queryResult.results.bindings[0];
-    return { personUri: result.person.value, personId: result.personId.value };
+    const personUri = result.person.value;
+    const personId = result.personId.value;
+
+    if(enableEmailClaim &&claims.vo_email && !result.email) {
+      await insertEmailForExistingUser(personUri, claims, graph)
+    }
+
+    return { personUri, personId };
   } else {
     const { personUri, personId } = await insertNewUser(claims, graph);
     return { personUri, personId };
@@ -105,6 +114,9 @@ const insertNewUser = async function(claims, graph) {
 
   if (claims.family_name)
     insertData += `${sparqlEscapeUri(person)} foaf:familyName ${sparqlEscapeString(claims.family_name)} . \n`;
+
+  if (enableEmailClaim &&claims.vo_email)
+    insertData += `${sparqlEscapeUri(person)} foaf:email ${sparqlEscapeString(claims.vo_email)} . \n`;
 
   insertData += `
       }
@@ -314,6 +326,20 @@ const selectCurrentSession = async function(account) {
   } else {
     return { sessionUri: null, sessionId: null, groupUri: null, groupId: null, roles: null };
   }
+};
+
+const insertEmailForExistingUser = async function(personUri, claims, graph) {
+  const email = claims.vo_email;
+
+  await update(`
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+    INSERT DATA {
+      GRAPH <${graph}> {
+        ${sparqlEscapeUri(personUri)} foaf:email ${sparqlEscapeString(email)} .
+      }
+    }
+  `);
 };
 
 export {


### PR DESCRIPTION
## ID

LPDC-1645

## Description

Add support for the `vo_email` claim, insert into the persoon object.

2 scenarios:
a) user has not used the application before; user doesn't have a foaf:Person object in the database yet
-> check if `claims.vo_email` is present, insert the email with the person creation

b) user already logged in before; user has a foaf:Person in the database
-> check if `claims.vo_email` is present and user doesn't have an email property already
-> run the insertEmailForExistingUser once

I've put the feature behind a feature flag `ENABLE_EMAIL_CLAIM` so other teams aren't impacted. In order to use the feature, the project needs to have selected the `vo_email` claim in the acm/idm dossier.

## Testing

Verify both scenarios:
a) where you haven't logged in before (might need to remove the persoon uri `http://data.lblod.info/id/persoon/...` if it already exists in the database). Check if the persoon is created correctly with the email
b) the user has logged in before, check if the email is inserted correctly.

## Setup

Setup LPDC acc/prod with their acm/idm credentials locally (make sure you have acm/idm rights for the env so you can test the login):

1. Set up your `/etc/hosts`

Add the following line to the file:
```
127.0.0.1 acc.lpdc.lokaalbestuur.lblod.info
```

2. Set up Caddy in your app

Add the following to your `docker-compose.override.yml`:
```
  # use this to test acmidm
  tlsproxy:
    image: caddy:2
    ports:
      - "443:443"
    environment:
      APPLICATION_ADDRESS: "acc.lpdc.lokaalbestuur.lblod.info"
    volumes:
      - ./config/tlsproxy-mock/Caddyfile:/etc/caddy/Caddyfile
    restart: "no"
```

and the following file as config, names `config/tlsproxy-mock/Caddyfile`:

```
https://{$APPLICATION_ADDRESS} {
  reverse_proxy identifier:80
  tls internal
}
```
3. Add the QA/PROD ACM/IDM environment variables to the lpdc and lpdc-login services.

<details>
<summary>ACC Environment variables</summary>

```yml
# docker-compose.override.yml
  lpdc:
    environment:
      EMBER_LOKET_URL: "https://loket.lblod.info/"
      EMBER_ACMIDM_CLIENT_ID: "8f483630-3e0f-4618-9538-528411444eaf"
      EMBER_ACMIDM_AUTH_URL: "https://authenticatie.vlaanderen.be/op/v1/auth"
      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie.vlaanderen.be/op/v1/logout"
      EMBER_ACMIDM_AUTH_REDIRECT_URL: "https://acc.lpdc.lokaalbestuur.lblod.info/authorization/callback"
      EMBER_ACMIDM_SWITCH_REDIRECT_URL: "https://acc.lpdc.lokaalbestuur.lblod.info/switch-login"
      EMBER_IPDC_URL: "https://productcatalogus.ipdc.vlaanderen.be"

  login-lpdc:
    image: lblod/acmidm-login-service:feature-email-claims
    environment:
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "8f483630-3e0f-4618-9538-528411444eaf"
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://acc.lpdc.lokaalbestuur.lblod.info/authorization/callback"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "snip"
      ENABLE_EMAIL_CLAIM: "true"
```
</details>

<details>
<summary>PROD Environment variables</summary>

```yml
# docker-compose.override.yml
  lpdc:
    environment:
      EMBER_IPDC_URL: "https://productcatalogus.ipdc.vlaanderen.be"
      EMBER_LOKET_URL: "https://loket.lokaalbestuur.vlaanderen.be/"
      EMBER_ACMIDM_CLIENT_ID: "c46f9a60-86d1-4288-bec8-2d186b0a9dab"
      EMBER_ACMIDM_AUTH_URL: "https://authenticatie.vlaanderen.be/op/v1/auth"
      EMBER_ACMIDM_LOGOUT_URL: "https://authenticatie.vlaanderen.be/op/v1/logout"
      EMBER_ACMIDM_AUTH_REDIRECT_URL: "https://lpdc.lokaalbestuur.vlaanderen.be/authorization/callback"
      EMBER_ACMIDM_SWITCH_REDIRECT_URL: "https://lpdc.lokaalbestuur.vlaanderen.be/switch-login"
  login-lpdc:
    image: lblod/acmidm-login-service:feature-email-claims
    environment:
      MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie.vlaanderen.be/op"
      MU_APPLICATION_AUTH_CLIENT_ID: "c46f9a60-86d1-4288-bec8-2d186b0a9dab"
      MU_APPLICATION_AUTH_REDIRECT_URI: "https://lpdc.lokaalbestuur.vlaanderen.be/authorization/callback"
      MU_APPLICATION_AUTH_CLIENT_SECRET: "see prod for the key"
      ENABLE_EMAIL_CLAIM: "true"
```
</details>
4. You're ready to go :)

Going to `APPLICATION_ADDRESS` in your browser should now give an error when your stack is down, and should show the app when the stack is up. You should then be able to log in as if you were on qa.

> Firefox displays a security warning because of certificate issues, but you can ignore it and force it to continue